### PR TITLE
[XLA:GPU] Print xla flags and DebugOptions after their initialization.

### DIFF
--- a/third_party/xla/xla/debug_options_flags.cc
+++ b/third_party/xla/xla/debug_options_flags.cc
@@ -1869,6 +1869,8 @@ static void AllocateFlags(DebugOptions* defaults) {
   flag_objects = new std::vector<tsl::Flag>();
   MakeDebugOptionsFlags(flag_objects, flag_values);
   ParseFlagsFromEnvAndDieIfUnknown("XLA_FLAGS", *flag_objects);
+  LOG(INFO) << "Debug options obtained from env: "
+            << flag_values->DebugString();
 }
 
 void AppendDebugOptionsFlags(std::vector<tsl::Flag>* flag_list,

--- a/third_party/xla/xla/parse_flags_from_env.cc
+++ b/third_party/xla/xla/parse_flags_from_env.cc
@@ -200,11 +200,9 @@ void ParseFlagsFromEnvAndIgnoreUnknown(
   auto* env_argv = &EnvArgvs()[envvar];
   SetArgvFromEnv(envvar, env_argv);  // a no-op if already initialized
 
-  if (VLOG_IS_ON(1)) {
-    VLOG(1) << "For env var " << envvar << " found arguments:";
-    for (int i = 0; i < env_argv->argc; i++) {
-      VLOG(1) << "  argv[" << i << "] = " << env_argv->argv[i];
-    }
+  LOG(INFO) << "For env var " << envvar << " found arguments:";
+  for (int i = 0; i < env_argv->argc; i++) {
+    LOG(INFO) << "  argv[" << i << "] = " << env_argv->argv[i];
   }
 
   QCHECK(tsl::Flags::Parse(&env_argv->argc, env_argv->argv.data(), flag_list))


### PR DESCRIPTION
There is no place where we print the flags and the debug options we use at the run time. At the same time it is the thing that we always need to know because we have so many of them. Lets print them once at the start time.

PiperOrigin-RevId: 665297540